### PR TITLE
correct execution of some tests on OSX machine

### DIFF
--- a/src/app/tests/DevToys.UnitTests/Tools/Formatters/Sql/SqlFormatterCommandLineToolTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tools/Formatters/Sql/SqlFormatterCommandLineToolTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using DevToys.CLI;
 using DevToys.Tools.Helpers.SqlFormatter;
@@ -83,8 +84,7 @@ VALUES
     }
 
     [Theory(DisplayName = "Format sql with valid standard sql should output valid sql")]
-    [InlineData(SqlLanguage.Sql, "SELECT * FETCH FIRST 2 ROWS ONLY;", "SELECT\r\n\t*\r\nFETCH FIRST\r\n\t2 ROWS ONLY;")]
-    [InlineData(SqlLanguage.Db2, "SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;", "SELECT\r\n\tcol1\r\nFROM\r\n\ttbl\r\nORDER BY\r\n\tcol2 DESC\r\nFETCH FIRST\r\n\t20 ROWS ONLY;")]
+    [MemberData(nameof(GetDataFormatSqlWithValidSqlAndTabShouldOutputValidSql), parameters: 2)]
     public async Task FormatSqlWithValidSqlAndTabShouldOutputValidSql(SqlLanguage language, string input, string expectedResult)
     {
         _tool.Input = input;
@@ -95,5 +95,33 @@ VALUES
         result.Should().Be(0);
         string consoleOutput = _consoleWriter.ToString().Trim();
         consoleOutput.Should().Be(expectedResult);
+    }
+
+    public static IEnumerable<object[]> GetDataFormatSqlWithValidSqlAndTabShouldOutputValidSql(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {SqlLanguage.Sql, "SELECT * FETCH FIRST 2 ROWS ONLY;", "SELECT\r\n\t*\r\nFETCH FIRST\r\n\t2 ROWS ONLY;"},
+                    new object[] {SqlLanguage.Db2, "SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;", "SELECT\r\n\tcol1\r\nFROM\r\n\ttbl\r\nORDER BY\r\n\tcol2 DESC\r\nFETCH FIRST\r\n\t20 ROWS ONLY;"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {SqlLanguage.Sql, "SELECT * FETCH FIRST 2 ROWS ONLY;", "SELECT\n\t*\nFETCH FIRST\n\t2 ROWS ONLY;"},
+                    new object[] {SqlLanguage.Db2, "SELECT col1 FROM tbl ORDER BY col2 DESC FETCH FIRST 20 ROWS ONLY;", "SELECT\n\tcol1\nFROM\n\ttbl\nORDER BY\n\tcol2 DESC\nFETCH FIRST\n\t20 ROWS ONLY;"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
     }
 }

--- a/src/app/tests/DevToys.UnitTests/Tools/Formatters/Sql/SqlFormatterGuiToolTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tools/Formatters/Sql/SqlFormatterGuiToolTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using DevToys.Core.Tools.Metadata;
 using DevToys.Tools.Tools.Formatters.Sql;
@@ -78,6 +79,15 @@ FETCH FIRST
         indentationOptions.Select(2); // Select OneTab
 
         await _tool.WorkTask;
-        _outputTextArea.Text.Should().Be("SELECT\r\n\t*\r\nFETCH FIRST\r\n\t2 ROWS ONLY;");
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            _outputTextArea.Text.Should().Be("SELECT\r\n\t*\r\nFETCH FIRST\r\n\t2 ROWS ONLY;");
+        }
+        else
+        {
+            _outputTextArea.Text.Should().Be("SELECT\n\t*\nFETCH FIRST\n\t2 ROWS ONLY;");
+        }
+
+
     }
 }

--- a/src/app/tests/DevToys.UnitTests/Tools/Formatters/Sql/SqlFormatterTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tools/Formatters/Sql/SqlFormatterTests.cs
@@ -1,4 +1,5 @@
-﻿using DevToys.Tools.Helpers.SqlFormatter.Languages;
+﻿using System.Runtime.InteropServices;
+using DevToys.Tools.Helpers.SqlFormatter.Languages;
 
 namespace DevToys.UnitTests.Tools.Formatters.Sql;
 
@@ -53,7 +54,17 @@ VALUES
 
         // recognizes @variables
         input = "SELECT @variable;";
-        expectedResult = "SELECT\r\n  @variable;";
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            expectedResult = "SELECT\r\n  @variable;";
+        }
+        else
+        {
+            expectedResult = "SELECT\n  @variable;";
+        }
+
+
         SqlFormatterTestHelpers.AssertFormat(formatter, input, expectedResult);
 
         // formats SELECT query with CROSS JOIN
@@ -121,7 +132,15 @@ WINDOW
 
         // formats window function and end as inline
         input = "SELECT window(time, \"1 hour\").start AS window_start, window(time, \"1 hour\").end AS window_end FROM tbl;";
-        expectedResult = "SELECT\r\n  window(time, \"1 hour\").start AS window_start,\r\n  window(time, \"1 hour\").end AS window_end\r\nFROM\r\n  tbl;";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            expectedResult = "SELECT\r\n  window(time, \"1 hour\").start AS window_start,\r\n  window(time, \"1 hour\").end AS window_end\r\nFROM\r\n  tbl;";
+        }
+        else
+        {
+            expectedResult = "SELECT\n  window(time, \"1 hour\").start AS window_start,\n  window(time, \"1 hour\").end AS window_end\nFROM\n  tbl;";
+        }
+
         SqlFormatterTestHelpers.AssertFormat(formatter, input, expectedResult);
     }
 
@@ -290,7 +309,15 @@ FETCH FIRST
         SqlFormatterTestHelpers.AssertFormat(formatter, input, expectedResult);
 
         // formats only -- as a line comment
-        input = "SELECT col FROM\r\n-- This is a comment\r\nMyTable;\r\n";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            input = "SELECT col FROM\r\n-- This is a comment\r\nMyTable;\r\n";
+        }
+        else
+        {
+            input = "SELECT col FROM\n-- This is a comment\nMyTable;\n";
+        }
+
         expectedResult =
 @"SELECT
   col
@@ -300,7 +327,15 @@ FROM
         SqlFormatterTestHelpers.AssertFormat(formatter, input, expectedResult);
 
         // recognizes _, $, #, . and @ as part of identifiers
-        input = "SELECT my_col$1#, col.2@ FROM tbl\r\n";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            input = "SELECT my_col$1#, col.2@ FROM tbl\r\n";
+        }
+        else
+        {
+            input = "SELECT my_col$1#, col.2@ FROM tbl\n";
+        }
+
         expectedResult =
 @"SELECT
   my_col$1#,
@@ -600,7 +635,15 @@ SET
 
         // recognizes $variables
         input = "SELECT $variable;";
-        expectedResult = "SELECT\r\n  $variable;";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            expectedResult = "SELECT\r\n  $variable;";
+        }
+        else
+        {
+            expectedResult = "SELECT\n  $variable;";
+        }
+
         SqlFormatterTestHelpers.AssertFormat(formatter, input, expectedResult);
     }
 

--- a/src/app/tests/DevToys.UnitTests/Tools/Helpers/JsonHelperTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tools/Helpers/JsonHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using DevToys.Tools.Helpers;
 using DevToys.Tools.Models;
@@ -24,42 +25,127 @@ public class JsonHelperTests
     }
 
     [Theory]
-    [InlineData(null, "")]
-    [InlineData("", "")]
-    [InlineData(" ", "")]
-    [InlineData("   {  }  ", "{}")]
-    [InlineData("   [  ]  ", "[]")]
-    [InlineData("   { \"foo\": 123 }  ", "{\r\n  \"foo\": 123\r\n}")]
+    [MemberData(nameof(GetDataFormatTwoSpaces), parameters: 6)]
     public async Task FormatTwoSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = await JsonHelper.FormatAsync(input, Indentation.TwoSpaces, false, new MockILogger(), CancellationToken.None);
         result.Data.Should().Be(expectedResult);
     }
 
+
+    public static IEnumerable<object[]> GetDataFormatTwoSpaces(int numTests)
+    {
+        var allData = new List<object[]>()
+        {
+            new object[] { null, "" },
+            new object[] { "", "" },
+            new object[] { " ", "" },
+            new object[] { "   {  }  ", "{}" },
+            new object[] { "   [  ]  ", "[]" },
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] { "   { \"foo\": 123 }  ", "{\r\n  \"foo\": 123\r\n}" },
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] { "   { \"foo\": 123 }  ", "{\n  \"foo\": 123\n}" },
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData(null, "")]
-    [InlineData("", "")]
-    [InlineData(" ", "")]
-    [InlineData("   {  }  ", "{}")]
-    [InlineData("   [  ]  ", "[]")]
-    [InlineData("   { \"foo\": 123 }  ", "{\r\n    \"foo\": 123\r\n}")]
+    [MemberData(nameof(GetDataFormatFourSpaces), parameters: 6)]
     public async Task FormatFourSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = await JsonHelper.FormatAsync(input, Indentation.FourSpaces, false, new MockILogger(), CancellationToken.None);
         result.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataFormatFourSpaces(int numTests)
+    {
+        var allData = new List<object[]>()
+        {
+            new object[] { null, "" },
+            new object[] { "", "" },
+            new object[] { " ", "" },
+            new object[] { "   {  }  ", "{}" },
+            new object[] { "   [  ]  ", "[]" },
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"   { \"foo\": 123 }  ", "{\r\n    \"foo\": 123\r\n}" },
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] { "   { \"foo\": 123 }  ", "{\n    \"foo\": 123\n}" },
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData(null, "")]
-    [InlineData("", "")]
-    [InlineData(" ", "")]
-    [InlineData("   {  }  ", "{}")]
-    [InlineData("   [  ]  ", "[]")]
-    [InlineData("   { \"foo\": 123 }  ", "{\r\n\t\"foo\": 123\r\n}")]
+    [MemberData(nameof(GetDataFormatOneTab), parameters: 6)]
     public async Task FormatOneTab(string input, string expectedResult)
     {
         ResultInfo<string> result = await JsonHelper.FormatAsync(input, Indentation.OneTab, false, new MockILogger(), CancellationToken.None);
         result.Data.Should().Be(expectedResult);
+    }
+
+    public static IEnumerable<object[]> GetDataFormatOneTab(int numTests)
+    {
+        var allData = new List<object[]>()
+        {
+            new object[] { null, "" },
+            new object[] { "", "" },
+            new object[] { " ", "" },
+            new object[] { "   {  }  ", "{}" },
+            new object[] { "   [  ]  ", "[]" },
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] { "   { \"foo\": 123 }  ", "{\r\n\t\"foo\": 123\r\n}" },
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] { "   { \"foo\": 123 }  ", "{\n\t\"foo\": 123\n}" },
+                }
+            );
+        }
+
+        return allData.Take(numTests);
     }
 
     [Theory]
@@ -144,8 +230,7 @@ public class JsonHelperTests
     }
 
     [Theory]
-    [InlineData("   - key: value  ", "[\r\n  {\r\n    \"key\": \"value\"\r\n  }\r\n]")]
-    [InlineData("   - key: value\r\n     key2: 1", "[\r\n  {\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }\r\n]")]
+    [MemberData(nameof(GetDataConvertFromYamlWithTwoSpaces), parameters: 2)]
     public void ConvertFromYamlWithTwoSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = JsonHelper.ConvertFromYaml(
@@ -156,9 +241,36 @@ public class JsonHelperTests
         result.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataConvertFromYamlWithTwoSpaces(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"   - key: value  ", "[\r\n  {\r\n    \"key\": \"value\"\r\n  }\r\n]"},
+                    new object[] {"   - key: value\r\n     key2: 1", "[\r\n  {\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }\r\n]"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"   - key: value  ", "[\n  {\n    \"key\": \"value\"\n  }\n]"},
+                    new object[] {"   - key: value\r\n     key2: 1", "[\n  {\n    \"key\": \"value\",\n    \"key2\": 1\n  }\n]"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData("   - key: value  ", "[\r\n    {\r\n        \"key\": \"value\"\r\n    }\r\n]")]
-    [InlineData("   - key: value\r\n     key2: 1", "[\r\n    {\r\n        \"key\": \"value\",\r\n        \"key2\": 1\r\n    }\r\n]")]
+    [MemberData(nameof(GetDataConvertFromYamlWithFourSpaces), parameters: 2)]
     public void ConvertFromYamlWithFourSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = JsonHelper.ConvertFromYaml(
@@ -169,12 +281,67 @@ public class JsonHelperTests
         result.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataConvertFromYamlWithFourSpaces(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"   - key: value  ", "[\r\n    {\r\n        \"key\": \"value\"\r\n    }\r\n]"},
+                    new object[] {"   - key: value\r\n     key2: 1", "[\r\n    {\r\n        \"key\": \"value\",\r\n        \"key2\": 1\r\n    }\r\n]"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"   - key: value  ", "[\n    {\n        \"key\": \"value\"\n    }\n]"},
+                    new object[] {"   - key: value\n     key2: 1", "[\n    {\n        \"key\": \"value\",\n        \"key2\": 1\n    }\n]"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData(null, null, "")]
-    [InlineData("{\"a\": \"asdf\", \"c\" : 545, \"b\": 33, \"array\": [{\"a\": \"asdf\", \"c\" : 545, \"b\": 42, \"array\": []}]}", "array.[0].b", "[\r\n  42\r\n]")]
+    [MemberData(nameof(GetDataJsonPathTests), parameters: 2)]
     public async Task JsonPathTests(string json, string jsonPath, string expectedResult)
     {
         (await JsonHelper.TestJsonPathAsync(json, jsonPath, new MockILogger(), CancellationToken.None))
             .Data.Should().Be(expectedResult);
+    }
+
+    public static IEnumerable<object[]> GetDataJsonPathTests(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {null, null, ""},
+                    new object[] {"{\"a\": \"asdf\", \"c\" : 545, \"b\": 33, \"array\": [{\"a\": \"asdf\", \"c\" : 545, \"b\": 42, \"array\": []}]}", "array.[0].b", "[\r\n  42\r\n]"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {null, null, ""},
+                    new object[] {"{\"a\": \"asdf\", \"c\" : 545, \"b\": 33, \"array\": [{\"a\": \"asdf\", \"c\" : 545, \"b\": 42, \"array\": []}]}", "array.[0].b", "[\n  42\n]"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
     }
 }

--- a/src/app/tests/DevToys.UnitTests/Tools/Helpers/XmlHelperTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tools/Helpers/XmlHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using DevToys.Tools.Helpers;
+﻿using System.Runtime.InteropServices;
+using DevToys.Tools.Helpers;
 using DevToys.Tools.Models;
 using DevToys.UnitTests.Mocks;
 
@@ -22,46 +23,138 @@ public class XmlHelperTests
     }
 
     [Theory]
-    [InlineData(null, "")]
-    [InlineData("", "")]
-    [InlineData(" ", "")]
-    [InlineData("<xml />", "<xml />")]
-    [InlineData("<root><xml /></root>", "<root>\r\n  <xml />\r\n</root>")]
-    [InlineData("<root><xml test=\"true\" /></root>", "<root>\r\n  <xml test=\"true\" />\r\n</root>", false)]
-    [InlineData("<root><xml test=\"true\" /></root>", "<root>\r\n  <xml\r\n    test=\"true\" />\r\n</root>", true)]
+    [MemberData(nameof(GetDataFormatTwoSpaces), parameters: 7)]
     public void FormatTwoSpaces(string input, string expectedResult, bool newLineOnAttributes = false)
     {
         ResultInfo<string> actual = XmlHelper.Format(input, Indentation.TwoSpaces, newLineOnAttributes, new MockILogger());
         actual.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataFormatTwoSpaces(int numTests)
+    {
+        var allData = new List<object[]>()
+        {
+            new object[] { null, "" },
+            new object[] { "","" },
+            new object[] { " ",""},
+            new object[] { "<xml />", "<xml />" },
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"<root><xml /></root>", "<root>\r\n  <xml />\r\n</root>"},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\r\n  <xml test=\"true\" />\r\n</root>", false},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\r\n  <xml\r\n    test=\"true\" />\r\n</root>", true},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"<root><xml /></root>", "<root>\n  <xml />\n</root>"},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\n  <xml test=\"true\" />\n</root>", false},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\n  <xml\n    test=\"true\" />\n</root>", true},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
+
     [Theory]
-    [InlineData(null, "")]
-    [InlineData("", "")]
-    [InlineData(" ", "")]
-    [InlineData("<xml />", "<xml />")]
-    [InlineData("<root><xml /></root>", "<root>\r\n    <xml />\r\n</root>")]
-    [InlineData("<root><xml test=\"true\" /></root>", "<root>\r\n    <xml test=\"true\" />\r\n</root>", false)]
-    [InlineData("<root><xml test=\"true\" /></root>", "<root>\r\n    <xml\r\n        test=\"true\" />\r\n</root>", true)]
+    [MemberData(nameof(GetDataFormatFourSpaces), parameters: 7)]
     public void FormatFourSpaces(string input, string expectedResult, bool newLineOnAttributes = false)
     {
         ResultInfo<string> actual = XmlHelper.Format(input, Indentation.FourSpaces, newLineOnAttributes, new MockILogger());
         actual.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataFormatFourSpaces(int numTests)
+    {
+        var allData = new List<object[]>()
+        {
+            new object[] { null, "" },
+            new object[] { "","" },
+            new object[] { " ",""},
+            new object[] { "<xml />", "<xml />" },
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                    new List<object[]>
+                    {
+                        new object[] { "<root><xml /></root>", "<root>\r\n    <xml />\r\n</root>" },
+                        new object[] { "<root><xml test=\"true\" /></root>", "<root>\r\n    <xml test=\"true\" />\r\n</root>", false },
+                        new object[] { "<root><xml test=\"true\" /></root>", "<root>\r\n    <xml\r\n        test=\"true\" />\r\n</root>", true },
+                    }
+                );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] { "<root><xml /></root>", "<root>\n    <xml />\n</root>" },
+                    new object[] { "<root><xml test=\"true\" /></root>", "<root>\n    <xml test=\"true\" />\n</root>", false },
+                    new object[] { "<root><xml test=\"true\" /></root>", "<root>\n    <xml\n        test=\"true\" />\n</root>", true },
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData(null, "")]
-    [InlineData("", "")]
-    [InlineData(" ", "")]
-    [InlineData("<xml />", "<xml />")]
-    [InlineData("<root><xml /></root>", "<root>\r\n\t<xml />\r\n</root>")]
-    [InlineData("<root><xml test=\"true\" /></root>", "<root>\r\n\t<xml test=\"true\" />\r\n</root>", false)]
-    [InlineData("<root><xml test=\"true\" /></root>", "<root>\r\n\t<xml\r\n\t\ttest=\"true\" />\r\n</root>", true)]
+    [MemberData(nameof(GetDataFormatOneTab), parameters: 7)]
     public void FormatOneTab(string input, string expectedResult, bool newLineOnAttributes = false)
     {
         ResultInfo<string> actual = XmlHelper.Format(input, Indentation.OneTab, newLineOnAttributes, new MockILogger());
         actual.Data.Should().Be(expectedResult);
     }
+
+    public static IEnumerable<object[]> GetDataFormatOneTab(int numTests)
+    {
+        var allData = new List<object[]>()
+        {
+            new object[] { null, "" },
+            new object[] { "","" },
+            new object[] { " ",""},
+            new object[] { "<xml />", "<xml />" },
+        };
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"<root><xml /></root>", "<root>\r\n\t<xml />\r\n</root>"},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\r\n\t<xml test=\"true\" />\r\n</root>", false},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\r\n\t<xml\r\n\t\ttest=\"true\" />\r\n</root>", true},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"<root><xml /></root>", "<root>\n\t<xml />\n</root>"},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\n\t<xml test=\"true\" />\n</root>", false},
+                    new object[] {"<root><xml test=\"true\" /></root>", "<root>\n\t<xml\n\t\ttest=\"true\" />\n</root>", true},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
 
     [Theory]
     [InlineData(null, "")]

--- a/src/app/tests/DevToys.UnitTests/Tools/Helpers/YamlHelperTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tools/Helpers/YamlHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System.Runtime.InteropServices;
+using System.Threading;
 using DevToys.Tools.Helpers;
 using DevToys.Tools.Models;
 
@@ -71,8 +72,7 @@ public class YamlHelperTests
     }
 
     [Theory]
-    [InlineData("{\r\n    \"key\": \"value\"\r\n  }", "key: value\r\n")]
-    [InlineData("{\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }", "key: value\r\nkey2: 1\r\n")]
+    [MemberData(nameof(GetDataConvertFromJsonWithTwoSpaces), parameters: 2)]
     public void ConvertFromJsonWithTwoSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = YamlHelper.ConvertFromJson(
@@ -83,9 +83,37 @@ public class YamlHelperTests
         result.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataConvertFromJsonWithTwoSpaces(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"{\r\n    \"key\": \"value\"\r\n  }", "key: value\r\n"},
+                    new object[] {"{\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }", "key: value\r\nkey2: 1\r\n"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"{\n    \"key\": \"value\"\n  }", "key: value\n"},
+                    new object[] {"{\n    \"key\": \"value\",\n    \"key2\": 1\n  }", "key: value\nkey2: 1\n"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
+
     [Theory]
-    [InlineData("{\r\n    \"key\": \"value\"\r\n  }", "key: value\r\n")]
-    [InlineData("{\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }", "key: value\r\nkey2: 1\r\n")]
+    [MemberData(nameof(GetDataConvertFromJsonWithFourSpaces), parameters: 2)]
     public void ConvertFromJsonWithFourSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = YamlHelper.ConvertFromJson(
@@ -96,9 +124,36 @@ public class YamlHelperTests
         result.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataConvertFromJsonWithFourSpaces(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"{\r\n    \"key\": \"value\"\r\n  }", "key: value\r\n"},
+                    new object[] {"{\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }", "key: value\r\nkey2: 1\r\n"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"{\n    \"key\": \"value\"\n  }", "key: value\n"},
+                    new object[] {"{\n    \"key\": \"value\",\n    \"key2\": 1\n  }", "key: value\nkey2: 1\n"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData("[\r\n  {\r\n    \"key\": \"value\"\r\n  }\r\n]", "- key: value\r\n")]
-    [InlineData("[\r\n  {\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }\r\n]", "- key: value\r\n  key2: 1\r\n")]
+    [MemberData(nameof(GetDataConvertFromJsonWithJsonRootArrayWithTwoSpaces), parameters: 2)]
     public void ConvertFromJsonWithJsonRootArrayWithTwoSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = YamlHelper.ConvertFromJson(
@@ -109,9 +164,35 @@ public class YamlHelperTests
         result.Data.Should().Be(expectedResult);
     }
 
+    public static IEnumerable<object[]> GetDataConvertFromJsonWithJsonRootArrayWithTwoSpaces(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"[\r\n  {\r\n    \"key\": \"value\"\r\n  }\r\n]", "- key: value\r\n"},
+                    new object[] {"[\r\n  {\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }\r\n]", "- key: value\r\n  key2: 1\r\n"},   }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"[\n  {\n    \"key\": \"value\"\n  }\n]", "- key: value\n"},
+                    new object[] {"[\n  {\n    \"key\": \"value\",\n    \"key2\": 1\n  }\n]", "- key: value\n  key2: 1\n"},
+                }
+            );
+        }
+
+        return allData.Take(numTests);
+    }
+
     [Theory]
-    [InlineData("[\r\n  {\r\n    \"key\": \"value\"\r\n  }\r\n]", "-   key: value\r\n")]
-    [InlineData("[\r\n  {\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }\r\n]", "-   key: value\r\n    key2: 1\r\n")]
+    [MemberData(nameof(GetDataConvertFromJsonWithJsonRootArrayWithFourSpaces), parameters: 2)]
     public void ConvertFromJsonWithJsonRootArrayWithFourSpaces(string input, string expectedResult)
     {
         ResultInfo<string> result = YamlHelper.ConvertFromJson(
@@ -120,5 +201,34 @@ public class YamlHelperTests
              new MockILogger(),
              CancellationToken.None);
         result.Data.Should().Be(expectedResult);
+    }
+
+    public static IEnumerable<object[]> GetDataConvertFromJsonWithJsonRootArrayWithFourSpaces(int numTests)
+    {
+        var allData = new List<object[]>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"[\r\n  {\r\n    \"key\": \"value\"\r\n  }\r\n]", "-   key: value\r\n"},
+                    new object[] {"[\r\n  {\r\n    \"key\": \"value\",\r\n    \"key2\": 1\r\n  }\r\n]", "-   key: value\r\n    key2: 1\r\n"},
+                }
+            );
+        }
+        else
+        {
+            allData.AddRange(
+                new List<object[]>
+                {
+                    new object[] {"[\n  {\n    \"key\": \"value\"\n  }\n]", "-   key: value\n"},
+                    new object[] {"[\n  {\n    \"key\": \"value\",\n    \"key2\": 1\n  }\n]", "-   key: value\n    key2: 1\n"},
+
+                }
+            );
+        }
+
+        return allData.Take(numTests);
     }
 }


### PR DESCRIPTION
(CR/LF OS depedent)

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

modified some tests to work on non-windows machines, comparing strings with new lines.

Issue Number: N/A

## What is the new behavior?

Changed the newline's behavior based on the operating system 

WIN `\r\n`  OTHER  `\n`
-
-
-

## Other information

ON macOs I still have 75 errors, you can confirm that unit tests are having problems on Mac ?
(thank you)

## Quality check

Before creating this PR:

- [ ] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [X] macOS (DevToys 2.0)
   - [ ] Linux (DevToys 2.0)