### PR TITLE
Fixed inconcistency and bug in IUIMultilineTextInput

### DIFF
--- a/src/app/dev/DevToys.Api/Tool/GUI/Components/IUIMultiLineTextInput.cs
+++ b/src/app/dev/DevToys.Api/Tool/GUI/Components/IUIMultiLineTextInput.cs
@@ -155,9 +155,9 @@ public static partial class GUI
     /// <remarks>
     /// This component is powered by Monaco Editor.
     /// </remarks>
-    public static IUIMultiLineTextInput MultilineTextInput()
+    public static IUIMultiLineTextInput MultiLineTextInput()
     {
-        return MultilineTextInput(null);
+        return MultiLineTextInput(null);
     }
 
     /// <summary>
@@ -167,7 +167,7 @@ public static partial class GUI
     /// This component is powered by Monaco Editor.
     /// </remarks>
     /// <param name="id">An optional unique identifier for this UI element.</param>
-    public static IUIMultiLineTextInput MultilineTextInput(string? id)
+    public static IUIMultiLineTextInput MultiLineTextInput(string? id)
     {
         return new UIMultilineTextInput(id);
     }
@@ -180,7 +180,7 @@ public static partial class GUI
     /// </remarks>
     /// <param name="id">An optional unique identifier for this UI element.</param>
     /// <param name="programmingLanguageName">the programming language name to use to colorize the text in the control.</param>
-    public static IUIMultiLineTextInput MultilineTextInput(string? id, string programmingLanguageName)
+    public static IUIMultiLineTextInput MultiLineTextInput(string? id, string programmingLanguageName)
     {
         return new UIMultilineTextInput(id).Language(programmingLanguageName);
     }

--- a/src/app/dev/DevToys.Api/Tool/GUI/Components/UIHighlightedTextSpan.cs
+++ b/src/app/dev/DevToys.Api/Tool/GUI/Components/UIHighlightedTextSpan.cs
@@ -20,10 +20,10 @@ public record UIHighlightedTextSpan : TextSpan
     /// <summary>
     /// Initializes a new instance of the <see cref="UIHighlightedTextSpan"/> class based on the original <see cref="TextSpan"/>.
     /// </summary>
-    /// <param name="original">The original <see cref="TextSpan"/>.</param>
+    /// <param name="span">The location where the text document should be highlighted <see cref="TextSpan"/>.</param>
     /// <param name="color">The color of the highlighted text span.</param>
-    protected UIHighlightedTextSpan(TextSpan original, UIHighlightedTextSpanColor color = UIHighlightedTextSpanColor.Default)
-        : base(original)
+    public UIHighlightedTextSpan(TextSpan span, UIHighlightedTextSpanColor color = UIHighlightedTextSpanColor.Default)
+        : base(span)
     {
         Color = color;
     }

--- a/src/app/dev/DevToys.Api/Tool/GUI/Components/UIHoverTooltip.cs
+++ b/src/app/dev/DevToys.Api/Tool/GUI/Components/UIHoverTooltip.cs
@@ -3,24 +3,33 @@
 /// <summary>
 /// Represents the Tooltip to display on hover
 /// </summary>
-public record UIHoverTooltip
+public record UIHoverTooltip : TextSpan
 {
     /// <summary>
-    /// Contain the position of the span to search
+    /// Initializes a new instance of the <see cref="UIHoverTooltip"/> class.
     /// </summary>
-    public TextSpan Span { get; }
-
-    /// <summary>
-    /// Contain the information we want to display on hover
-    /// </summary>
-    public string Description { get; }
-
-    /// <summary>
-    /// Create a new isntance of the <see cref="UIHoverTooltip"/> class.
-    /// </summary>
-    public UIHoverTooltip(TextSpan span, string description)
+    /// <param name="startPosition">The start position of the highlighted text span.</param>
+    /// <param name="length">The length of the highlighted text span.</param>
+    /// <param name="tooltip">The information to display on hover.</param>
+    public UIHoverTooltip(int startPosition, int length, string tooltip)
+        : base(startPosition, length)
     {
-        Span = span;
-        Description = description;
+        Tooltip = tooltip;
     }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UIHoverTooltip"/> class.
+    /// </summary>
+    /// <param name="span">The location in the text document where the tooltip must appear.</param>
+    /// <param name="tooltip">The information to display on hover.</param>
+    public UIHoverTooltip(TextSpan span, string tooltip)
+        : base(span)
+    {
+        Tooltip = tooltip;
+    }
+
+    /// <summary>
+    /// Contain the information to display on hover
+    /// </summary>
+    public string Tooltip { get; }
 }

--- a/src/app/dev/DevToys.Blazor/BuiltInTools/Settings/SettingsGuiTool.cs
+++ b/src/app/dev/DevToys.Blazor/BuiltInTools/Settings/SettingsGuiTool.cs
@@ -198,7 +198,7 @@ internal sealed class SettingsGuiTool : IGuiTool
                                         stateDescriptionWhenOn: Settings.PasteClearsTextStateDescriptionWhenOn,
                                         stateDescriptionWhenOff: null),
 
-                                MultilineTextInput("text-editor-render-preview")
+                                MultiLineTextInput("text-editor-render-preview")
                                     .Title(Settings.TextEditorPreview)
                                     .AlignVertically(UIVerticalAlignment.Top)
                                     .Language("json")


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

1. The method to create `IUIMultiLineTextInput` is inconsistent with `IUISingleLineTextInput`.
2. The `UIHoverTooltip` is inconsistent with `UIHighlightedTextSpan`, which they do similar things (add decoration to text)
3. There is a bug: when setting Highlights, it removed Tooltip and vice versa.

## What is the new behavior?

1. Made the API more consistent (This causes a breaking change. Will need to update NuGet package and `DevToys.Tools`)
2. Fixed the bug in `MultiLineTextInputPresenter`

## Other information

![image](https://github.com/DevToys-app/DevToys/assets/3747805/f4586268-622c-4dc3-bd5c-faeeecf0c424)

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux