### PR TITLE
Made settings name less prone to collision

### DIFF
--- a/src/app/dev/DevToys.Api/Settings/SettingDefinition.cs
+++ b/src/app/dev/DevToys.Api/Settings/SettingDefinition.cs
@@ -39,12 +39,7 @@ public readonly struct SettingDefinition<T> : IEquatable<SettingDefinition<T>>
     {
         Guard.IsNotNullOrWhiteSpace(name);
 
-        if (name.Length > 255)
-        {
-            // Come one! Make it shorter!
-            ThrowHelper.ThrowArgumentOutOfRangeException(nameof(name), "Setting name is limited to 255 characters.");
-        }
-        else if (name.Contains('='))
+        if (name.Contains('='))
         {
             // For portable apps, settings are stored in a .ini file where the format is "setting_name=value".
             // Therefore, the setting name shouldn't contain "=".
@@ -154,10 +149,15 @@ public readonly struct SettingDefinition<T> : IEquatable<SettingDefinition<T>>
                 && assembly is not null
                 && assembly != currentAssembly)
             {
-                string className = type.Name;
-                string? namespaceName = type.Namespace;
                 string? callingAssemblyName = assembly.GetName().Name;
-                return $"[{callingAssemblyName}]{namespaceName}.{className}.{baseName}";
+                string settingName = $"{callingAssemblyName}.{baseName}";
+
+                if (settingName.Length > 255)
+                {
+                    ThrowHelper.ThrowArgumentOutOfRangeException(nameof(settingName), "Setting name is limited to 255 characters.");
+                }
+
+                return settingName;
             }
         }
 

--- a/src/app/dev/DevToys.Api/Settings/SettingDefinition.cs
+++ b/src/app/dev/DevToys.Api/Settings/SettingDefinition.cs
@@ -1,4 +1,7 @@
-﻿namespace DevToys.Api;
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace DevToys.Api;
 
 /// <summary>
 /// Represents the definition of a setting in the application.
@@ -48,7 +51,7 @@ public readonly struct SettingDefinition<T> : IEquatable<SettingDefinition<T>>
             ThrowHelper.ThrowArgumentException(nameof(name), "Setting name cannot contain '='.");
         }
 
-        Name = name;
+        Name = GenerateName(name);
         DefaultValue = defaultValue;
     }
 
@@ -125,5 +128,39 @@ public readonly struct SettingDefinition<T> : IEquatable<SettingDefinition<T>>
     public static bool operator !=(SettingDefinition<T> left, SettingDefinition<T> right)
     {
         return !(left == right);
+    }
+
+    /// <summary>
+    /// Generates the name of the setting by using the calling assembly, namespace, and class name.
+    /// This is used to prevent collision between various extensions that may use the same setting name.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static string GenerateName(string baseName)
+    {
+        // Using Stack Trace might not give us the right information in AOT scenarios as the call stack may be different.
+        // Good thing is: as DevToys use MEF, we don't use AOT. So, we are good to go.
+        // But this is something we may need to revisit in the future.
+        var stackTrace = new StackTrace();
+        StackFrame[] stackFrames = stackTrace.GetFrames();
+        var currentAssembly = Assembly.GetExecutingAssembly();
+
+        foreach (StackFrame frame in stackFrames)
+        {
+            MethodBase? method = frame.GetMethod();
+            Type? type = method?.ReflectedType;
+            Assembly? assembly = type?.Assembly;
+
+            if (type is not null
+                && assembly is not null
+                && assembly != currentAssembly)
+            {
+                string className = type.Name;
+                string? namespaceName = type.Namespace;
+                string? callingAssemblyName = assembly.GetName().Name;
+                return $"[{callingAssemblyName}]{namespaceName}.{className}.{baseName}";
+            }
+        }
+
+        return baseName;
     }
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #1139

## What is the new behavior?

SettingsDefinition now use the assembly name, namespace and class of the caller in order to reduce chances of colliding setting name.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux