### PR TITLE
Minor updates on MacOS paths and documentation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,7 @@
             "preLaunchTask": "Build DevToys MacOS",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/bin/Debug/AnyCPU/DevToys.MacOS/net8.0-macos/osx-arm64/DevToys.MacOS.app/Contents/MacOS/DevToys.MacOS",
+            "program": "${workspaceFolder}/bin/Debug/AnyCPU/DevToys.MacOS/net8.0-macos/osx-arm64/DevToys.app/Contents/MacOS/DevToys",
             "args": [],
             "cwd": "${workspaceFolder}/src/app/dev/platforms/desktop/DevToys.MacOS",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -28,7 +28,7 @@
             "preLaunchTask": "Build DevToys MacOS",
             "type": "coreclr",
             "request": "launch",
-            "program": "${workspaceFolder}/bin/Debug/AnyCPU/DevToys.MacOS/net8.0-macos/osx-x64/DevToys.MacOS.app/Contents/MacOS/DevToys.MacOS",
+            "program": "${workspaceFolder}/bin/Debug/AnyCPU/DevToys.MacOS/net8.0-macos/osx-x64/DevToys.app/Contents/MacOS/DevToys",
             "args": [],
             "cwd": "${workspaceFolder}/src/app/dev/platforms/desktop/DevToys.MacOS",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,9 +78,9 @@ You can contribute to DevToys app by:
 #### Special note for `DevToys.MacOS`
 Most of the `DevToys.MacOS` app runs in a web browser (Safari). In order to access the Safari developer tools with macOS to debug the HTML/CSS/JS of the Blazor app, you might need to follow the following instructions:
 1. Open desktop Safari.
-2. Select the Safari > Preferences > Advanced > Show Develop menu in the menu bar checkbox.
+2. Select the Safari > Preferences > Advanced > Show features for web developers in the menu bar checkbox.
 3. Run the `DevToys.MacOS` app in macOS.
-4. Return to Safari. Select Develop > {REMOTE INSPECTION TARGET} > 0.0.0.0, where the {REMOTE INSPECTION TARGET} placeholder is either the devices's plain name (for example, MacBook Pro) or the device's serial number (for example XMVM7VFF10). If multiple entries for 0.0.0.0 are present, select the entry that highlights the BlazorWebView. The BlazorWebView is highlighted in blue in macOS when the correct 0.0.0.0 entry is selected.
+4. Return to Safari. On the main menu, select Develop > {REMOTE INSPECTION TARGET} > 0.0.0.0, where the {REMOTE INSPECTION TARGET} placeholder is either the devices's plain name (for example, MacBook Pro) or the device's serial number (for example XMVM7VFF10). If multiple entries for 0.0.0.0 are present, select the entry that highlights the BlazorWebView. The BlazorWebView is highlighted in blue in macOS when the correct 0.0.0.0 entry is selected.
 5. The Web Inspector window appears for the BlazorWebView.
 
 ## From Linux


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [X] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The paths for MacOS build on `launch.json` are obsolete and need to be fixed to work properly.

Issue Number: #1126 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixes the paths on the launch tasks "DevToys MacOS arm64" and "DevToys MacOS x64"

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [X] macOS
   - [ ] Linux