### PR TITLE
Remove the "CompileTypescript" from Windows

### DIFF
--- a/init.ps1
+++ b/init.ps1
@@ -26,3 +26,10 @@ ExecSafe { & $PSScriptRoot\tools\Restore-MonacoEditor.ps1 -RootFolder $PSScriptR
 
 Write-Host "Done."
 Write-Output "---------------------------------------"
+
+# Install nodes modules
+Write-Host "Installing node modules"
+Get-ChildItem $PSScriptRoot\src\ -rec |? { $_.FullName.EndsWith('DevToys.Blazor.csproj') } |% {
+    Write-Host "Installing node modules for $($_)..."
+    ExecSafe { & npm install $_.Directory  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "devtoys": "file:src/app/dev/DevToys.Blazor"
+  }
+}

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -6,8 +6,8 @@
     <GirCore>0.5.0-preview.1</GirCore>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="CommunityToolkit.Common" Version="$(CommunityToolkitVersion)" />
-    <PackageVersion Include="CommunityToolkit.Diagnostics" Version="$(CommunityToolkitVersion)" />
+    <PackageVersion Include="CommunityToolkit.Common" Version="8.2.2" />
+    <PackageVersion Include="CommunityToolkit.Diagnostics" Version="8.2.2" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="$(CommunityToolkitVersion)" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
     <PackageVersion Include="FluentAssertions" Version="6.11.0" />
@@ -23,7 +23,7 @@
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Abstractions" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Embedded" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(DotNetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(DotNetVersion)" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="$(DotNetVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.3.2" />
@@ -32,8 +32,8 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NuGet.Packaging" Version="6.9.1" />
     <PackageVersion Include="Nuke.Common" Version="8.0.0" />
-    <PackageVersion Include="OneOf" Version="3.0.263" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.3" />
+    <PackageVersion Include="OneOf" Version="3.0.271" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.4" />
     <PackageVersion Include="System.Text.Json" Version="$(DotNetVersion)" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.ComponentModel.Composition" Version="$(DotNetVersion)" />

--- a/src/app/dev/DevToys.Blazor/DevToys.Blazor.csproj
+++ b/src/app/dev/DevToys.Blazor/DevToys.Blazor.csproj
@@ -7,6 +7,10 @@
     <TypeScriptTarget>ES6</TypeScriptTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(DefineConstants) == '__MACOS__'">
+    <PrepareForBuildDependsOn>CompileTypeScript;GetTypeScriptOutputForPublishing;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" />

--- a/src/app/dev/DevToys.Blazor/DevToys.Blazor.csproj
+++ b/src/app/dev/DevToys.Blazor/DevToys.Blazor.csproj
@@ -5,9 +5,6 @@
     <RootNamespace>DevToys.Blazor</RootNamespace>
     <EnableDefaultCssItems>false</EnableDefaultCssItems>
     <TypeScriptTarget>ES6</TypeScriptTarget>
-
-    <!-- Only needed on Mac? -->
-    <PrepareForBuildDependsOn>CompileTypeScript;GetTypeScriptOutputForPublishing;$(PrepareForBuildDependsOn)</PrepareForBuildDependsOn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1170

## What is the new behavior?

- We now detect if we are compiling DevToys.Blazor on MacOs and if it's the case we enable the CompileTypescript

## Other information


    Severity	Code	Description	Project	File	Line	Suppression State	Details
    Error	MSB4057	The target "CompileTypeScript" does not exist in the project.	DevToys.Blazor	C:\Program Files\Microsoft 
    Visual Studio\2022\Community\MSBuild\Current\Bin\amd64\Microsoft.Common.CurrentVersion.targets	1182		

![image](https://github.com/DevToys-app/DevToys/assets/2970321/72e42ab5-c3bb-481e-b0b5-d3cdc91cb5a3)

## Quality check

Before creating this PR:

- [ ] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux