### PR TITLE
Linux.Clipboard: Use a new method to read text

### DIFF
--- a/src/app/dev/platforms/desktop/DevToys.Linux/Core/Clipboard.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Linux/Core/Clipboard.cs
@@ -89,26 +89,7 @@ internal sealed partial class Clipboard : IClipboard
         try
         {
             Gdk.Clipboard clipboard = Gdk.Display.GetDefault()!.GetClipboard();
-            var tcs = new TaskCompletionSource<string?>();
-
-            Gdk.Internal.Clipboard.ReadTextAsync(
-                clipboard.Handle,
-                IntPtr.Zero,
-                new Gio.Internal.AsyncReadyCallbackAsyncHandler(
-                    (_, args, _) =>
-                    {
-                        string? result
-                            = Gdk.Internal.Clipboard.ReadTextFinish(
-                                clipboard.Handle,
-                                args.Handle,
-                                out GLib.Internal.ErrorOwnedHandle error)
-                            .ConvertToString();
-
-                        tcs.SetResult(result);
-                    }).NativeCallback, IntPtr.Zero);
-
-            string? clipboardContent = await tcs.Task;
-            return clipboardContent;
+            return await clipboard.ReadTextAsync();
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
GirCore provides a new async method to read text from a Gdk.Clipboard.

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [ ] macOS
   - [x] Linux