### PR TITLE
Fixed an issue where the app wrongly detect an update

### DIFF
--- a/src/app/dev/DevToys.Core/AppHelper.cs
+++ b/src/app/dev/DevToys.Core/AppHelper.cs
@@ -109,14 +109,14 @@ public static class AppHelper
                             .GetExecutingAssembly()
                             .GetCustomAttribute(typeof(AssemblyInformationalVersionAttribute))!;
 
-                    string currentVersion
+                    string currentVersionString
                         = assemblyInformationalVersion.InformationalVersion
                             .TrimStart('v')
                             .Replace("-alpha", string.Empty)
                             .Replace("-beta", string.Empty)
                             .Replace("-preview", string.Empty)
                             .Replace("-pre", string.Empty);
-                    string? releaseVersion
+                    string? gitHubVersionString
                         = potentialRelease.Name?
                             .TrimStart('v')
                             .Replace("-alpha", string.Empty)
@@ -124,9 +124,14 @@ public static class AppHelper
                             .Replace("-preview", string.Empty)
                             .Replace("-pre", string.Empty);
 
-                    if (!string.IsNullOrEmpty(releaseVersion) && !string.IsNullOrEmpty(currentVersion))
+                    if (!string.IsNullOrEmpty(gitHubVersionString) && !string.IsNullOrEmpty(currentVersionString))
                     {
-                        if (new System.Version(releaseVersion) > new System.Version(currentVersion))
+                        var gitHubReleaseVersion = new System.Version(gitHubVersionString);
+                        var currentVersion = new System.Version(currentVersionString);
+
+                        if (gitHubReleaseVersion.Major > currentVersion.Major
+                            || (gitHubReleaseVersion.Major == currentVersion.Major && gitHubReleaseVersion.Minor > currentVersion.Minor)
+                            || (gitHubReleaseVersion.Major == currentVersion.Major && gitHubReleaseVersion.Minor == currentVersion.Minor && gitHubReleaseVersion.Build > currentVersion.Build))
                         {
                             return true;
                         }

--- a/src/app/tests/DevToys.UnitTests/Core/AppHelperTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Core/AppHelperTests.cs
@@ -103,6 +103,34 @@ public class AppHelperTests
     }
 
     [Fact]
+    public async Task CheckForUpdate_Preview_NoUpdate2_Async()
+    {
+        GitHubRelease[] releases
+            = [
+                new GitHubRelease
+                {
+                    Draft = false,
+                    PreRelease = true,
+                    Name = "v0.0.0"
+                },
+              ];
+        string releasesJson = JsonSerializer.Serialize(releases);
+
+        var mockWebClientService = new Mock<IWebClientService>();
+        mockWebClientService
+            .Setup(service => service.SafeGetStringAsync(It.IsAny<Uri>(), CancellationToken.None))
+            .ReturnsAsync(releasesJson);
+
+        var mockVersionService = new Mock<IVersionService>();
+        mockVersionService
+            .Setup(service => service.IsPreviewVersion())
+            .Returns(true);
+
+        bool result = await AppHelper.CheckForUpdateAsync(mockWebClientService.Object, mockVersionService.Object, CancellationToken.None);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task CheckForUpdate_StableAsync()
     {
         GitHubRelease[] releases


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

DevToys current version is `v2.0-preview.1`. We recently dropped the Revision number (4th digit) because the MS Store and Homebrew only accept 3 digits version number. This regressed the update detection.

GitHub release is "v2.0.1.0", which is parsed as a `System.Version(2, 0, 1, 0)`.
DevToys running version is "v2.0-preview.1", which is parsed as `System.Version(2, 0, 1, -1)`.

Because of this, DevToys finds that there's a newer version on GitHub, which is wrong.

## What is the new behavior?

We now only check the first 3 digits (Major, Minor, Build).

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux