### PR TITLE
Fix bug where we can't restore the window when maximized on Windows 10/11

### DIFF
--- a/src/app/dev/platforms/desktop/DevToys.Windows/Controls/MicaWindowWithOverlay.xaml.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Windows/Controls/MicaWindowWithOverlay.xaml.cs
@@ -32,6 +32,8 @@ public abstract partial class MicaWindowWithOverlay : Window
     private Button? _maximizeButton;
     private Button? _minimizeButton;
     private StackPanel? _windowStateButtonsStackPanel;
+    private bool _isMouseButtonDownOnDraggableTitleBarArea;
+    private Point _mouseDownPositionOnDraggableTitleBarArea;
 
     protected MicaWindowWithOverlay()
     {
@@ -127,7 +129,9 @@ public abstract partial class MicaWindowWithOverlay : Window
         _restoreButton.Click += RestoreButton_Click;
         _maximizeButton.Click += MaximizeButton_Click;
         draggableTitleBarArea.MouseLeftButtonDown += DraggableTitleBarArea_MouseLeftButtonDown;
+        draggableTitleBarArea.MouseLeftButtonUp += DraggableTitleBarArea_MouseLeftButtonUp;
         draggableTitleBarArea.MouseRightButtonUp += DraggableTitleBarArea_MouseRightButtonUp;
+        draggableTitleBarArea.MouseMove += DraggableTitleBarArea_MouseMove;
         this.PreviewKeyDown += MicaWindowWithOverlay_PreviewKeyDown;
         overlayControl.WndProc = WndProc;
     }
@@ -218,12 +222,65 @@ public abstract partial class MicaWindowWithOverlay : Window
                 {
                     SystemCommands.MaximizeWindow(this);
                 }
+
+                return;
             }
         }
         else
         {
-            // Move the window.
-            DragMove();
+            if (WindowState == WindowState.Maximized)
+            {
+                _isMouseButtonDownOnDraggableTitleBarArea = true;
+                _mouseDownPositionOnDraggableTitleBarArea = e.GetPosition(this);
+            }
+            else
+            {
+                try
+                {
+                    DragMove();
+                }
+                catch
+                {
+                }
+            }
+        }
+    }
+
+    private void DraggableTitleBarArea_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        _isMouseButtonDownOnDraggableTitleBarArea = false;
+    }
+
+    private void DraggableTitleBarArea_MouseMove(object sender, System.Windows.Input.MouseEventArgs e)
+    {
+        if (_isMouseButtonDownOnDraggableTitleBarArea
+            && e.LeftButton == MouseButtonState.Pressed
+            && WindowState == WindowState.Maximized)
+        {
+            Point position = e.GetPosition(this);
+            Point screenPosition = PointToScreen(position);
+
+            Vector vector = _mouseDownPositionOnDraggableTitleBarArea - position;
+
+            if (vector.Length > 1)
+            {
+                double relativeDistance = position.X / ActualWidth;
+
+                WindowState = WindowState.Normal;
+
+                double actualDistance = ActualWidth * relativeDistance;
+
+                try
+                {
+                    Top = screenPosition.Y - position.Y;
+                    Left = screenPosition.X - actualDistance;
+
+                    DragMove();
+                }
+                catch
+                {
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1219


https://github.com/DevToys-app/DevToys/assets/3747805/f080b117-35a9-4432-954b-75104db66de9



## What is the new behavior?

https://github.com/DevToys-app/DevToys/assets/3747805/9444e6f0-6e99-4d53-9043-d5aca5876c76



## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux