### PR TITLE
Remove loading indication for Monaco

### DIFF
--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditor.razor
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditor.razor
@@ -29,10 +29,6 @@
             <div class="monaco-editor-standalone-container @(IsActuallyEnabled ? string.Empty : "disabled")"
                  @ref=Element>
 
-                <ProgressRing id="@($"{Id}-loading")"
-                              IsIndeterminate="@ShowLoading"
-                              IsVisible="@ShowLoading" />
-
                 <div id="@Id" class="monaco-editor-standalone-instance @(IsActuallyEnabled ? string.Empty : "disabled")"></div>
 
                 <div class="monaco-editor-standalone-underline" />

--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditor.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditor.razor.cs
@@ -42,8 +42,6 @@ public partial class MonacoEditor : RicherMonacoEditorBase
     [Parameter]
     public UITextLineNumber? LineNumberMode { get; set; }
 
-    private bool ShowLoading { get; set; }
-
     protected override void OnInitialized()
     {
         base.OnInitialized();
@@ -67,8 +65,6 @@ public partial class MonacoEditor : RicherMonacoEditorBase
     {
         if (firstRender)
         {
-            InvokeAsync(DisplayLoadingIfSlowLoadingAsync).Forget();
-
             // Get desired options
             StandaloneEditorConstructionOptions options = ConstructionOptions?.Invoke(this) ?? new();
 
@@ -145,7 +141,6 @@ public partial class MonacoEditor : RicherMonacoEditorBase
         lock (_lock)
         {
             _isLoaded = true;
-            ShowLoading = false;
 
             if (SettingsProvider is not null)
             {
@@ -188,27 +183,6 @@ public partial class MonacoEditor : RicherMonacoEditorBase
     {
         Guard.IsNotNull(_themeListener);
         return _themeListener.ActualAppTheme == ApplicationTheme.Dark ? BuiltinTheme.VsDark : BuiltinTheme.Vs;
-    }
-
-    private async Task DisplayLoadingIfSlowLoadingAsync()
-    {
-        // Let's not show the progress ring during the first 100ms. We know customers tends to perceive anything
-        // faster than 100ms as "instant", so no need to bother the user with a very shortly displayed progress ring
-        // if we succeed to load within 100ms.
-        // https://psychology.stackexchange.com/questions/1664/what-is-the-threshold-where-actions-are-perceived-as-instant
-
-        const int Delay = 100;
-
-        await Task.Delay(Delay);
-
-        lock (_lock)
-        {
-            if (!_isLoaded)
-            {
-                ShowLoading = true;
-                StateHasChanged();
-            }
-        }
     }
 
     private void ApplyWordWrapOption(EditorOptions editorOptions)

--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor
@@ -29,10 +29,6 @@
             <div class="monaco-editor-standalone-container @(IsActuallyEnabled ? string.Empty : "disabled")"
                  @ref=Element>
 
-                <ProgressRing id="@($"{Id}-loading")"
-                              IsIndeterminate="@ShowLoading"
-                              IsVisible="@ShowLoading" />
-
                 <div id="@Id" class="monaco-editor-standalone-instance"></div>
 
                 <div class="monaco-editor-standalone-underline" />

--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor.cs
@@ -21,8 +21,6 @@ public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
     [Parameter]
     public Func<MonacoEditorDiff, StandaloneDiffEditorConstructionOptions>? ConstructionOptions { get; set; }
 
-    private bool ShowLoading { get; set; }
-
     protected override void OnInitialized()
     {
         base.OnInitialized();
@@ -38,8 +36,6 @@ public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
         {
             Guard.IsNull(OriginalEditor);
             Guard.IsNull(ModifiedEditor);
-
-            InvokeAsync(DisplayLoadingIfSlowLoadingAsync).Forget();
 
             // Get desired options
             StandaloneDiffEditorConstructionOptions options = ConstructionOptions?.Invoke(this) ?? new();
@@ -134,7 +130,6 @@ public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
         lock (_lock)
         {
             _isLoaded = true;
-            ShowLoading = false;
             StateHasChanged();
         }
     }
@@ -162,26 +157,5 @@ public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
     {
         Guard.IsNotNull(_themeListener);
         return _themeListener.ActualAppTheme == ApplicationTheme.Dark ? BuiltinTheme.VsDark : BuiltinTheme.Vs;
-    }
-
-    private async Task DisplayLoadingIfSlowLoadingAsync()
-    {
-        // Let's not show the progress ring during the first 100ms. We know customers tends to perceive anything
-        // faster than 100ms as "instant", so no need to bother the user with a very shortly displayed progress ring
-        // if we succeed to load within 100ms.
-        // https://psychology.stackexchange.com/questions/1664/what-is-the-threshold-where-actions-are-perceived-as-instant
-
-        const int Delay = 100;
-
-        await Task.Delay(Delay);
-
-        lock (_lock)
-        {
-            if (!_isLoaded)
-            {
-                ShowLoading = true;
-                StateHasChanged();
-            }
-        }
     }
 }

--- a/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor.cs
+++ b/src/app/dev/DevToys.Blazor/Components/Text/MonacoEditor/MonacoEditorDiff.razor.cs
@@ -6,7 +6,6 @@ namespace DevToys.Blazor.Components;
 public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
 {
     private readonly object _lock = new();
-    private bool _isLoaded;
     private bool _oldIsActuallyEnabled;
     private bool _oldReadOnlyState;
 
@@ -129,7 +128,6 @@ public partial class MonacoEditorDiff : RicherMonacoEditorDiffBase
         base.OnEditorLoaded();
         lock (_lock)
         {
-            _isLoaded = true;
             StateHasChanged();
         }
     }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [X] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: #1243

## What is the new behavior?

From what I've seen personally and from what customers share on GitHub and social network, Monaco tend to load instantly, and our loading progress indication is more bothering than helpful. Let's remove it completely.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux