### PR TITLE
[MacOS] Fixed an issue where the app is completely blank on MacOS 15 Beta

### DIFF
--- a/src/app/dev/platforms/desktop/DevToys.MacOS/Controls/BlazorWebView/BlazorWebViewManager.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/Controls/BlazorWebView/BlazorWebViewManager.cs
@@ -196,7 +196,7 @@ public partial class BlazorWebViewManager : WebViewManager
             else
             {
                 // Invoke the UrlLoading event to allow overriding the default link handling behavior
-                var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWkWebView.AppOriginUri);
+                var callbackArgs = UrlLoadingEventArgs.CreateWithDefaultLoadingStrategy(uri, BlazorWkWebView.AppOriginUri.Value);
                 _webView.OnUrlLoading(callbackArgs);
 
                 strategy = callbackArgs.UrlLoadingStrategy;
@@ -228,7 +228,7 @@ public partial class BlazorWebViewManager : WebViewManager
         {
             // We need to intercept the redirects to the app scheme because Safari will block them.
             // We will handle these redirects through the Navigation Manager.
-            if (_currentUri?.Host != BlazorWkWebView.AppHostAddress)
+            if (_currentUri?.Host != BlazorWkWebView.AppHostAddress.Value)
             {
                 return;
             }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1279

## What is the new behavior?

`BlazorWebView` now navigates to `app://localhost` instead of `app://0.0.0.0` on MacOS 15.0

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [X] macOS
   - [ ] Linux