### PR TITLE
Added conflict internal name resolution for resource assembly identifier.

### DIFF
--- a/src/app/dev/DevToys.Core/Tools/GuiToolProvider.cs
+++ b/src/app/dev/DevToys.Core/Tools/GuiToolProvider.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.ObjectModel;
+using System.Globalization;
 using System.Reflection;
+using System.Resources;
 using DevToys.Core.Tools.Metadata;
 using DevToys.Core.Tools.ViewItems;
 using DevToys.Localization;
@@ -625,7 +627,21 @@ public sealed partial class GuiToolProvider
         {
             if (string.Equals(item.Metadata.InternalComponentName, guiToolMetadata.ResourceManagerAssemblyIdentifier, StringComparison.Ordinal))
             {
-                return item.Value.GetType().Assembly;
+                Assembly assembly = item.Value.GetType().Assembly;
+
+                var resourceManager = new ResourceManager(guiToolMetadata.ResourceManagerBaseName, assembly);
+                try
+                {
+                    resourceManager.GetString(guiToolMetadata.ShortDisplayTitleResourceName);
+                }
+                catch (MissingManifestResourceException)
+                {
+                    // The resource manager is not valid. Let's try to find another one.
+                    // This can happen in case if the internal component name is conflicting between multiple extensions.
+                    continue;
+                }
+
+                return assembly;
             }
         }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

Some extensions use the same name in `IResourceAssemblyIdentifier`, and it causes some conflicts internally.

## What is the new behavior?

We now test the resource manager and try with a different assembly if it doesn't work. I also updated the documentation (in Documentation repository) to explain that the name should be unique.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux