### PR TITLE
Fixed a regression where Linux theme is not properly detected

### DIFF
--- a/src/app/dev/platforms/desktop/DevToys.Linux/Core/ThemeListener.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Linux/Core/ThemeListener.cs
@@ -2,14 +2,18 @@
 using DevToys.Core.Settings;
 using DevToys.Blazor.Components;
 using DevToys.Blazor.Core.Services;
+using Gio;
+using GLib;
+using Microsoft.Extensions.Logging;
 using Object = GObject.Object;
 using static GObject.Object;
 
 namespace DevToys.Linux.Core;
 
 [Export(typeof(IThemeListener))]
-internal sealed class ThemeListener : IThemeListener
+internal sealed partial class ThemeListener : IThemeListener
 {
+    private readonly ILogger _logger;
     private readonly ISettingsProvider _settingsProvider;
     private readonly Gtk.Settings _gtkSettings;
 
@@ -19,6 +23,8 @@ internal sealed class ThemeListener : IThemeListener
     [ImportingConstructor]
     public ThemeListener(ISettingsProvider settingsProvider)
     {
+        _logger = this.Log();
+
         // Listen for app settings
         _settingsProvider = settingsProvider;
         _settingsProvider.SettingChanged += SettingsProvider_SettingChanged;
@@ -147,8 +153,44 @@ internal sealed class ThemeListener : IThemeListener
 
     private AvailableApplicationTheme GetCurrentSystemTheme()
     {
-        return _gtkSettings.GtkApplicationPreferDarkTheme || (_gtkSettings.GtkThemeName?.Contains("Dark", StringComparison.OrdinalIgnoreCase) ?? false)
-            ? AvailableApplicationTheme.Dark
-            : AvailableApplicationTheme.Light;
+        try
+        {
+            var bus = DBusConnection.Get(BusType.Session);
+            using var parameters = Variant.NewTuple([
+                Variant.NewString("org.freedesktop.appearance"), Variant.NewString("color-scheme")
+            ]);
+
+            using Variant ret = bus.CallSync(
+                busName: "org.freedesktop.portal.Desktop",
+                objectPath: "/org/freedesktop/portal/desktop",
+                interfaceName: "org.freedesktop.portal.Settings",
+                methodName: "Read",
+                parameters: parameters,
+                replyType: VariantType.New("(v)"),
+                flags: DBusCallFlags.None,
+                timeoutMsec: 2000,
+                cancellable: null
+            );
+
+            uint userThemePreference = ret.GetChildValue(0).GetVariant().GetVariant().GetUint32();
+
+            return userThemePreference switch
+            {
+                1 => AvailableApplicationTheme.Dark,
+                2 => AvailableApplicationTheme.Light,
+                _ => _gtkSettings.GtkApplicationPreferDarkTheme ||
+                     (_gtkSettings.GtkThemeName?.Contains("Dark", StringComparison.OrdinalIgnoreCase) ?? false)
+                    ? AvailableApplicationTheme.Dark
+                    : AvailableApplicationTheme.Light
+            };
+        }
+        catch (Exception ex)
+        {
+            LogGetLinuxThemeFailed(ex);
+            return AvailableApplicationTheme.Light;
+        }
     }
+
+    [LoggerMessage(0, LogLevel.Error, "Failed to detect Linux theme.")]
+    partial void LogGetLinuxThemeFailed(Exception ex);
 }

--- a/src/app/dev/platforms/desktop/DevToys.Linux/LinuxProgram.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Linux/LinuxProgram.cs
@@ -31,6 +31,7 @@ internal partial class LinuxProgram
 
     internal LinuxProgram()
     {
+        Gio.Module.Initialize();
         Application = Gtk.Application.New(null, Gio.ApplicationFlags.NonUnique);
 
         GLib.Functions.SetPrgname("DevToys");


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1381

## What is the new behavior?

Use DBus to retrieve the `org.freedesktop.appearance` parameter to detect the theme on Linux Mint, Ubuntu, Fedora.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [X] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [ ] Did you verify that the change work in Release build configuration
- [ ] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [ ] macOS
   - [X] Linux