### PR TITLE
 Fix GetChildElementById no access to elements inside Card

### DIFF
--- a/src/app/dev/DevToys.Api/Tool/GUI/Components/IUICard.cs
+++ b/src/app/dev/DevToys.Api/Tool/GUI/Components/IUICard.cs
@@ -1,7 +1,7 @@
 ﻿namespace DevToys.Api;
 
 /// <summary>
-/// A component that represents a empty card and <see cref="IUIElement"/> for the option value.
+/// A component that represents an empty card and <see cref="IUIElement"/> for the option value.
 /// </summary>
 public interface IUICard : IUIElement
 {
@@ -12,7 +12,7 @@ public interface IUICard : IUIElement
 }
 
 [DebuggerDisplay($"Id = {{{nameof(Id)}}}")]
-internal class UICard : UIElement, IUICard
+internal class UICard : UIElementWithChildren, IUICard
 {
     internal UICard(string? id, IUIElement uiElement)
         : base(id)
@@ -22,6 +22,11 @@ internal class UICard : UIElement, IUICard
     }
 
     public IUIElement UIElement { get; }
+
+    protected override IEnumerable<IUIElement> GetChildren()
+    {
+        yield return UIElement;
+    }
 }
 
 public static partial class GUI

--- a/src/app/tests/DevToys.UnitTests/Tool/GUI/Components/UIElementWithChildrenTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tool/GUI/Components/UIElementWithChildrenTests.cs
@@ -72,4 +72,18 @@ public class UIElementWithChildrenTests
         );
         Assert.Equal(child1.Object, element.GetChildElementById("child"));
     }
+
+    [Fact]
+    public void GetChildElementById_ReturnsChild_WhenChildIsCard()
+    {
+        var child = new Mock<IUIElement>();
+        child.Setup(c => c.Id).Returns("child-id");
+
+        var card = new UICard("card-id", child.Object);
+
+        var element = new TestUIElement("parent", new List<IUIElement> { card });
+
+        Assert.Equal(card, element.GetChildElementById("card-id"));
+        Assert.Equal(child.Object, element.GetChildElementById("child-id"));
+    }
 }

--- a/src/app/tests/DevToys.UnitTests/Tool/GUI/Components/UIElementWithChildrenTests.cs
+++ b/src/app/tests/DevToys.UnitTests/Tool/GUI/Components/UIElementWithChildrenTests.cs
@@ -1,0 +1,75 @@
+﻿namespace DevToys.UnitTests.Tool.GUI.Components;
+
+public class UIElementWithChildrenTests
+{
+    private class TestUIElement : UIElementWithChildren
+    {
+        private readonly IEnumerable<IUIElement> _children;
+
+        public TestUIElement(string id, IEnumerable<IUIElement> children)
+            : base(id)
+        {
+            _children = children;
+        }
+
+        protected override IEnumerable<IUIElement> GetChildren() => _children;
+    }
+
+    [Fact]
+    public void GetChildElementById_ReturnsNull_WhenIdIsNullOrEmpty()
+    {
+        var element = new TestUIElement("parent", new List<IUIElement>());
+        Assert.Null(element.GetChildElementById(null!));
+        Assert.Null(element.GetChildElementById(string.Empty));
+    }
+
+    [Fact]
+    public void GetChildElementById_ReturnsNull_WhenChildNotFound()
+    {
+        var child = new Mock<IUIElement>();
+        child.Setup(c => c.Id).Returns("child1");
+
+        var element = new TestUIElement("parent", new List<IUIElement> { child.Object });
+        Assert.Null(element.GetChildElementById("child2"));
+    }
+
+    [Fact]
+    public void GetChildElementById_ReturnsChild_WhenChildFound()
+    {
+        var child = new Mock<IUIElement>();
+        child.Setup(c => c.Id).Returns("child1");
+
+        var element = new TestUIElement("parent", new List<IUIElement> { child.Object });
+        Assert.Equal(child.Object, element.GetChildElementById("child1"));
+    }
+
+    [Fact]
+    public void GetChildElementById_ReturnsNestedChild_WhenNestedChildFound()
+    {
+        var nestedChild = new Mock<IUIElement>();
+        nestedChild.Setup(c => c.Id).Returns("nestedChild");
+
+        var child = new Mock<IUIElementWithChildren>();
+        child.Setup(c => c.Id).Returns("child1");
+        child.Setup(c => c.GetChildElementById("nestedChild")).Returns(nestedChild.Object);
+
+        var element = new TestUIElement("parent", new List<IUIElement> { child.Object });
+        Assert.Equal(nestedChild.Object, element.GetChildElementById("nestedChild"));
+    }
+
+    [Fact]
+    public void GetChildElementById_ReturnsFirstMatchingChild_WhenMultipleChildrenWithSameId()
+    {
+        var child1 = new Mock<IUIElement>();
+        child1.Setup(c => c.Id).Returns("child");
+
+        var child2 = new Mock<IUIElement>();
+        child2.Setup(c => c.Id).Returns("child");
+
+        var element = new TestUIElement(
+            "parent",
+            new List<IUIElement> { child1.Object, child2.Object }
+        );
+        Assert.Equal(child1.Object, element.GetChildElementById("child"));
+    }
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Fixes: #1406 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `GetChildElementById` now also iterates over `UIElement` inside `UICard`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Added basic unit tests for `GetChildElementById`.

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [ ] If necessary and if possible, did you verify your changes on:
   - [x] Windows
   - [ ] macOS
   - [ ] Linux