### PR TITLE
Added support of per-extension assembly isolation

### DIFF
--- a/src/app/dev/DevToys.Core/Mef/AssemblyIsolation.cs
+++ b/src/app/dev/DevToys.Core/Mef/AssemblyIsolation.cs
@@ -3,6 +3,7 @@ using System.Runtime.Loader;
 
 namespace DevToys.Core.Mef;
 
+// See https://learn.microsoft.com/en-us/dotnet/core/dependency-loading/understanding-assemblyloadcontext
 internal sealed class AssemblyIsolation : AssemblyLoadContext
 {
     private readonly AssemblyDependencyResolver _resolver;

--- a/src/app/dev/DevToys.Core/Mef/AssemblyIsolation.cs
+++ b/src/app/dev/DevToys.Core/Mef/AssemblyIsolation.cs
@@ -1,0 +1,25 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace DevToys.Core.Mef;
+
+internal sealed class AssemblyIsolation : AssemblyLoadContext
+{
+    private readonly AssemblyDependencyResolver _resolver;
+
+    internal AssemblyIsolation(string entryPointAssemblyPath)
+    {
+        _resolver = new AssemblyDependencyResolver(entryPointAssemblyPath);
+    }
+
+    protected override Assembly? Load(AssemblyName assemblyName)
+    {
+        string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+        if (assemblyPath != null)
+        {
+            return LoadFromAssemblyPath(assemblyPath);
+        }
+
+        return null;
+    }
+}

--- a/src/app/dev/DevToys.Core/Mef/RecursiveDirectoryCatalog.cs
+++ b/src/app/dev/DevToys.Core/Mef/RecursiveDirectoryCatalog.cs
@@ -124,6 +124,8 @@ internal sealed partial class RecursiveDirectoryCatalog : ComposablePartCatalog,
         {
             AssemblyCount++;
 
+            // Create an isolation context for the plugin.
+            // This allows to load dependencies version that the plugin asks, even if DevToys uses a different version of that same dependency.
             _assemblyIsolation ??= new AssemblyIsolation(filePath);
 
             Assembly assembly = _assemblyIsolation.LoadFromAssemblyPath(filePath);

--- a/src/app/dev/DevToys.Core/Mef/RecursiveDirectoryCatalog.cs
+++ b/src/app/dev/DevToys.Core/Mef/RecursiveDirectoryCatalog.cs
@@ -14,6 +14,7 @@ internal sealed partial class RecursiveDirectoryCatalog : ComposablePartCatalog,
 {
     private readonly ILogger _logger;
     private readonly string _path;
+    private AssemblyIsolation? _assemblyIsolation;
     private AggregateCatalog? _aggregateCatalog;
 
     /// <summary>
@@ -122,7 +123,11 @@ internal sealed partial class RecursiveDirectoryCatalog : ComposablePartCatalog,
         try
         {
             AssemblyCount++;
-            var asmCat = new AssemblyCatalog(filePath);
+
+            _assemblyIsolation ??= new AssemblyIsolation(filePath);
+
+            Assembly assembly = _assemblyIsolation.LoadFromAssemblyPath(filePath);
+            var asmCat = new AssemblyCatalog(assembly);
 
             // Force MEF to load the plugin and figure out if there are any exports
             // good assemblies will not throw the RTLE exception and can be added to the catalog


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: fix #1430

## What is the new behavior?

Added a `AssemblyLoadContext` per extension discovered in DevToys, which allows each extension to load every assemblies it needs in an isolated manner. This allows .NET to load and use multiple versions of an assembly at the same time.

**Note:** This feature is NOT supported by Android, iOS and WebAssembly. But we don't care since we don't target them.

## Validation

You can test the change by building and installing the 2 extensions in this ZIP: 
[ExtensionTest.zip](https://github.com/user-attachments/files/17534932/ExtensionTest.zip)

## Other information

![image](https://github.com/user-attachments/assets/caf62b8d-48b2-4744-b1e8-d05f48ebc115)

![image](https://github.com/user-attachments/assets/8d9abe3b-7d3f-448f-9851-1b94cdf8fca5)


## Quality check

Before creating this PR:

- [X] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [X] Did you build the app and test your changes?
- [ ] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [X] Did you verify that the change work in Release build configuration
- [X] Did you verify that all unit tests pass
- [X] If necessary and if possible, did you verify your changes on:
   - [X] Windows
   - [ ] macOS
   - [ ] Linux