### PR TITLE
fix(linux): pin WebView response buffer to stop served-asset corruption

### DIFF
--- a/src/app/dev/platforms/desktop/DevToys.Linux/Components/BlazorWebView/BlazorWebView.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Linux/Components/BlazorWebView/BlazorWebView.cs
@@ -1,5 +1,6 @@
 using System.Collections.Specialized;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using DevToys.Api;
 using DevToys.Blazor.Core;
 using Gdk;
@@ -352,18 +353,31 @@ internal sealed partial class BlazorWebView : IDisposable
                 return;
             }
 
-            using var ms = new MemoryStream();
-            ms.Write(responseBytes.AsSpan());
-            nint streamPtr = MemoryInputStream.NewFromData(ref ms.GetBuffer()[0], (uint)ms.Length, _ => { });
+            // g_memory_input_stream_new_from_data() does NOT copy the buffer: it keeps the raw
+            // pointer and reads from it asynchronously (after this method returns), calling the
+            // destroy notify only once WebKitGTK is done with the stream. The previous code handed
+            // it a pointer into a managed, unpinned MemoryStream buffer together with a no-op
+            // destroy notify, so the GC was free to move, collect or reuse that memory before/while
+            // WebKitGTK read it. The result was corrupted responses (zeroed bytes, and bytes from
+            // other concurrent requests bleeding in), which broke script parsing in JavaScriptCore
+            // ("SyntaxError: Invalid character: '\0'", garbled assets) and left the `devtoys` global
+            // undefined. Pin the response buffer for the whole lifetime of the stream and release it
+            // from the destroy notify.
+            // A non-empty backing array is required so `ref buffer[0]` is valid even for an empty
+            // body; the exposed length stays responseBytes.Length.
+            byte[] buffer = responseBytes.Length == 0 ? new byte[1] : responseBytes;
+            GCHandle responseHandle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            nint streamPtr = MemoryInputStream.NewFromData(
+                ref buffer[0], (uint)responseBytes.Length, _ => responseHandle.Free());
             using var inputStream = new InputStream(streamPtr, false);
 
             var headers = MessageHeaders.New(MessageHeadersType.Response);
-            headers.SetContentLength(ms.Length);
+            headers.SetContentLength(responseBytes.Length);
 
             // Disable local caching. This will prevent user scripts from executing correctly.
             headers.Append("Cache-Control", "no-cache, max-age=0, must-revalidate, no-store");
 
-            var response = URISchemeResponse.New(inputStream, ms.Length);
+            var response = URISchemeResponse.New(inputStream, responseBytes.Length);
             response.SetHttpHeaders(headers);
             response.SetContentType(contentType);
             response.SetStatus((uint)statusCode, statusMessage);


### PR DESCRIPTION
## Problem
  On Linux, DevToys often renders with broken icons and throws "An unhandled error has occurred" on the first interaction. The `devtoys` JS global ends up undefined, so every JS-interop call
  fails (`devtoys.DOM.addFontToDocument`, `devtoys.Popover.connect`, `devtoys.DOM.setFocus`, …).

  Root cause: the `app://` URI-scheme handler in `BlazorWebView.cs` serves embedded static assets through `g_memory_input_stream_new_from_data()`, which does **not** copy the buffer — it
  keeps the raw pointer and reads from it asynchronously, calling the destroy-notify only once WebKitGTK is done with the stream. The code passed a pointer into a **managed, unpinned**
  `MemoryStream` buffer together with a **no-op destroy-notify**, so the GC was free to move/collect/reuse that memory before or while WebKitGTK read it.

  That produced corrupted responses: zeroed bytes (e.g. `SyntaxError: Invalid character: '\0'` in `require.js`) and bytes from other concurrent requests bleeding in (e.g. `blazor.webview.js`
  content inside `devtoys.g.js`). Because it depends on GC timing it's intermittent — the first asset (`index.html`) usually survives while later concurrent ones get corrupted. WebView2 /
  WKWebView don't hit it because their serving paths differ.

  ## Fix
  Pin the response buffer for the whole lifetime of the stream and free the `GCHandle` from the destroy-notify. Also drops a redundant `MemoryStream` copy and uses the actual content length.

  ## Testing
  Built `DevToys.Linux` from source with the patch (self-contained linux-x64) and ran it on Ubuntu 24.04 (tested against both WebKitGTK 2.44 and 2.52): icons render correctly and
  navigation/popovers work, with no JS errors. Reproduced the original corruption without the patch on the same machine