### PR TITLE
fix: Text Comparer not showing any diff on macOS and Linux

### DIFF
--- a/src/app/dev/platforms/desktop/DevToys.Linux/Components/BlazorWebView/BlazorWebView.cs
+++ b/src/app/dev/platforms/desktop/DevToys.Linux/Components/BlazorWebView/BlazorWebView.cs
@@ -374,8 +374,8 @@ internal sealed partial class BlazorWebView : IDisposable
         private byte[] GetResponseBytes(string? url, out string contentType, out int statusCode,
             out string statusMessage)
         {
+            url = RemovePossibleQueryStringAndFragment(url);
             bool allowFallbackOnHostPage = IsUriBaseOfPage(AppOriginUri, url);
-            url = RemovePossibleQueryString(url);
 
             if (_blazorWebView._webViewManager!.TryGetResponseContentInternal(
                     url,
@@ -401,17 +401,19 @@ internal sealed partial class BlazorWebView : IDisposable
             return [];
         }
 
-        private static string RemovePossibleQueryString(string? url)
+        private static string RemovePossibleQueryStringAndFragment(string? url)
         {
             if (string.IsNullOrEmpty(url))
             {
                 return string.Empty;
             }
 
-            int indexOfQueryString = url.IndexOf('?', StringComparison.Ordinal);
-            return indexOfQueryString == -1
+            // Requests reach this handler with their fragment intact, which an HTTP request would never carry.
+            // Monaco relies on it to label its web workers (workerMain.js#editorWorkerService).
+            int indexOfQueryStringOrFragment = url.IndexOfAny(['?', '#']);
+            return indexOfQueryStringOrFragment == -1
                 ? url
-                : url.Substring(0, indexOfQueryString);
+                : url[..indexOfQueryStringOrFragment];
         }
 
         private static bool IsUriBaseOfPage(Uri baseUri, string? uriString)

--- a/src/app/dev/platforms/desktop/DevToys.MacOS/Controls/BlazorWebView/BlazorWKWebView.cs
+++ b/src/app/dev/platforms/desktop/DevToys.MacOS/Controls/BlazorWebView/BlazorWKWebView.cs
@@ -354,8 +354,8 @@ internal sealed partial class BlazorWkWebView : IDisposable
 
         private byte[] GetResponseBytes(string? url, out string contentType, out int statusCode)
         {
+            url = RemovePossibleQueryStringAndFragment(url);
             bool allowFallbackOnHostPage = IsUriBaseOfPage(AppOriginUri.Value, url);
-            url = RemovePossibleQueryString(url);
 
             if (_blazorWebView._webViewManager!.TryGetResponseContentInternal(
                     url,
@@ -386,17 +386,19 @@ internal sealed partial class BlazorWkWebView : IDisposable
         {
         }
 
-        private static string RemovePossibleQueryString(string? url)
+        private static string RemovePossibleQueryStringAndFragment(string? url)
         {
             if (string.IsNullOrEmpty(url))
             {
                 return string.Empty;
             }
 
-            int indexOfQueryString = url.IndexOf('?', StringComparison.Ordinal);
-            return indexOfQueryString == -1
+            // Requests reach this handler with their fragment intact, which an HTTP request would never carry.
+            // Monaco relies on it to label its web workers (workerMain.js#editorWorkerService).
+            int indexOfQueryStringOrFragment = url.IndexOfAny(['?', '#']);
+            return indexOfQueryStringOrFragment == -1
                 ? url
-                : url.Substring(0, indexOfQueryString);
+                : url[..indexOfQueryStringOrFragment];
         }
 
         private static bool IsUriBaseOfPage(Uri baseUri, string? uriString)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] UI change (please include screenshot!)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Internationalization and localization
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/DevToys-app/DevToys/issues/1296 https://github.com/DevToys-app/DevToys/issues/1623 https://github.com/DevToys-app/DevToys/issues/1562 https://github.com/DevToys-app/DevToys/issues/1541

On macOS and Linux, the Text Comparer shows both panes but never renders any `+`/`-` highlighting. Monaco editor computes diffs in a web worker, and labels that worker with a URL fragment:

```
app://localhost/.../vs/base/worker/workerMain.js#editorWorkerService
```

macOS (WKWebView) and Linux (WebKitGTK) are both WebKit, and WebKit passes the fragment to the custom scheme handler. Both platforms carried the same `RemovePossibleQueryString`, which cut the URL at `?` but not at `#`, so the file lookup missed and the worker received Blazor's placeholder text as its script:

```
SyntaxError: Unexpected identifier 'is'
```

No worker means no diff computation, so no decorations. Windows is unaffected because WebView2 is Chromium and doesn't pass the fragment to its resource handler.

## What is the new behavior?

| Build | Worker request | Text Comparer |
| --- | --- | --- |
| before | 125 bytes, `There is no content at …` | no highlighting |
| after the fix | 309 809 bytes of worker source | highlighting |

Verified on macOS 26.5 arm64 and Ubuntu 26.04.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

## Quality check

Before creating this PR:

- [x] Did you follow the code style guideline as described in [CONTRIBUTING.md](https://github.com/veler/DevToys/blob/main/CONTRIBUTING.md)
- [x] Did you build the app and test your changes?
- [x] Did you check for accessibility? On Windows, you can use Accessibility Insights for this.
- [x] Did you verify that the change work in Release build configuration
- [x] Did you verify that all unit tests pass
- [x] If necessary and if possible, did you verify your changes on:
   - [ ] Windows
   - [x] macOS
   - [ ] Linux
